### PR TITLE
Suggested fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ spec.add_dependency "zaikio-client-helpers"
 require "zaikio-client-helpers"
 ```
 
+3. Extend the base class for your models:
+
+```ruby
+class User < Zaikio::Client::Model
+  # ...
+end
+```
+
 ## Parsing API responses
 
 Spyke needs a couple of extra things in addition to JSON parsing, so this library exposes
@@ -53,17 +61,10 @@ Faraday.new do |f|
 end
 ```
 
-Then, in our classes which use pagination, we need to add this Spyke module:
+If you aren't inheriting `Zaikio::Client::Model`, you should mixin our pagination library
+like so: `include Zaikio::Client::Helpers::Pagination::Spyke`.
 
-```ruby
-class Model < Spyke::Base
-  include Zaikio::Client::Helpers::Pagination::Spyke
-end
-```
-
-> It is also safe to include this module just in your base class for all models to share.
-
-The module works by overriding the `#all` method on a relation, so it will keep fetching
+The library works by overriding the `#all` method on a relation, so it will keep fetching
 pages from the remote API until there are none left:
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -79,3 +79,6 @@ to call `each` or `to_a` to materialize the records):
 ```ruby
 Model.all.lazy.take(2).map(&:id).to_a
 ```
+
+Note that if the endpoint doesn't support pagination (i.e. doesn't return a `Current-Page`
+header), pagination is automatically disabled.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ end
 ```
 
 If you aren't inheriting `Zaikio::Client::Model`, you should mixin our pagination library
-like so: `include Zaikio::Client::Helpers::Pagination::Spyke`.
+like so: `include Zaikio::Client::Helpers::Pagination`.
 
 The library works by overriding the `#all` method on a relation, so it will keep fetching
 pages from the remote API until there are none left:

--- a/lib/zaikio/client/helpers/pagination.rb
+++ b/lib/zaikio/client/helpers/pagination.rb
@@ -11,7 +11,8 @@ module Zaikio::Client::Helpers
 
     METADATA_KEY = :pagination
 
-    # Faraday Middleware for extracting any pagination headers into the env hash.
+    # Faraday Middleware for extracting any pagination headers into the a top-level
+    # :metadata hash, or the env hash for non-JSON responses.
     #
     # @example Usage
     #   conn = Faraday.new do |f|
@@ -45,81 +46,65 @@ module Zaikio::Client::Helpers
       end
     end
 
-    # Compatibility with Spyke, when included it overrides the `#all` method on a
-    # Spyke::Relation to paginate the whole collection.
-    #
-    # @example Usage for a single model
-    #   class Model < Spyke::Base
-    #     include Zaikio::Client::Helpers::Pagination::Spyke
-    #   end
-    #
-    # @example Include in a base class for all models
-    #   class Base < Spyke::Base
-    #     include Zaikio::Client::Helpers::Pagination::Spyke
-    #   end
-    #   class Model < Base; end
-    module Spyke
-      extend ActiveSupport::Concern
+    extend ActiveSupport::Concern
 
-      included do
-        %i[page per_page].each do |symbol|
-          scope symbol, ->(value) { where(symbol => value) }
+    included do
+      scope :page, ->(value) { where(page: value) }
+      scope :per_page, ->(value) { where(per_page: value) }
+    end
+
+    module ClassMethods
+      # Overrides the method included by Spyke::Scoping to return paginated relations.
+      def all
+        current_scope || Relation.new(self, uri: uri)
+      end
+    end
+
+    class Relation < Spyke::Relation
+      HEADERS.each_key do |symbol|
+        define_method(symbol) do
+          find_some.metadata[METADATA_KEY][symbol]
         end
       end
 
-      module ClassMethods
-        # Overrides the method included by Spyke::Scoping to return paginated relations.
-        def all
-          current_scope || Relation.new(self, uri: uri)
-        end
+      def first_page?
+        current_page == 1
       end
 
-      class Relation < ::Spyke::Relation
-        HEADERS.each_key do |symbol|
-          define_method(symbol) do
-            find_some.metadata[METADATA_KEY][symbol]
-          end
-        end
+      def next_page
+        current_page + 1
+      end
 
-        def first_page?
-          current_page == 1
-        end
+      def last_page?
+        current_page >= total_pages
+      end
 
-        def next_page
-          current_page + 1
-        end
+      def supports_pagination?
+        current_page.present?
+      end
 
-        def last_page?
-          current_page >= total_pages
-        end
+      # Unlike the default implementation in Spyke, this version of #each is recursive
+      # and will repeatedly paginate through the remote API until it runs out of
+      # records.
+      #
+      # To avoid this behaviour, you can ask for a Lazy enumerator to take just the
+      # records you need, e.g.:
+      #   User.all.lazy.take(3).to_a
+      #   #=> [.., .., ..]
+      def each(&block)
+        return to_enum(:each) unless block_given?
 
-        def supports_pagination?
-          current_page.present?
-        end
+        find_some.each(&block)
+        return if !supports_pagination? || last_page?
 
-        # Unlike the default implementation in Spyke, this version of #each is recursive
-        # and will repeatedly paginate through the remote API until it runs out of
-        # records.
-        #
-        # To avoid this behaviour, you can ask for a Lazy enumerator to take just the
-        # records you need, e.g.:
-        #   User.all.lazy.take(3).to_a
-        #   #=> [.., .., ..]
-        def each(&block)
-          return to_enum(:each) unless block_given?
+        puts "There are #{total_count} pages, I will load more pages automatically" if first_page?
+        clone.page(next_page).each(&block)
+      end
 
-          find_some.each(&block)
-          return if !supports_pagination? || last_page?
-
-          puts "There are #{total_count} pages, I will load more pages automatically" if first_page?
-          clone.page(next_page).each(&block)
-        end
-
-        def clone
-          # We use cloning when fetching a second page using the same scope/query, however
-          # we want to clear any loaded records from @find_some before doing so.
-          super.tap { |obj| obj.instance_variable_set(:@find_some, nil) }
-        end
+      def clone
+        # We use cloning when fetching a second page using the same scope/query, however
+        # we want to clear any loaded records from @find_some before doing so.
+        super.tap { |obj| obj.instance_variable_set(:@find_some, nil) }
       end
     end
   end

--- a/lib/zaikio/client/model.rb
+++ b/lib/zaikio/client/model.rb
@@ -1,0 +1,9 @@
+require_relative "helpers/pagination"
+
+module Zaikio
+  module Client
+    class Model < Spyke::Base
+      include Helpers::Pagination::Spyke
+    end
+  end
+end

--- a/lib/zaikio/client/model.rb
+++ b/lib/zaikio/client/model.rb
@@ -3,7 +3,7 @@ require_relative "helpers/pagination"
 module Zaikio
   module Client
     class Model < Spyke::Base
-      include Helpers::Pagination::Spyke
+      include Helpers::Pagination
     end
   end
 end

--- a/test/zaikio/client/helpers/pagination_test.rb
+++ b/test/zaikio/client/helpers/pagination_test.rb
@@ -36,9 +36,9 @@ class Zaikio::Client::Helpers::Pagination::FaradayMiddlewareTest < ActiveSupport
   end
 end
 
-class Zaikio::Client::Helpers::Pagination::SpykeTest < ActiveSupport::TestCase
+class Zaikio::Client::Helpers::PaginationTest < ActiveSupport::TestCase
   class User < Spyke::Base
-    include Zaikio::Client::Helpers::Pagination::Spyke
+    include Zaikio::Client::Helpers::Pagination
   end
 
   def setup

--- a/test/zaikio/client/helpers/pagination_test.rb
+++ b/test/zaikio/client/helpers/pagination_test.rb
@@ -125,6 +125,7 @@ class Zaikio::Client::Helpers::Pagination::SpykeTest < ActiveSupport::TestCase
     })
 
     relation = User.all
+    assert relation.supports_pagination?
     assert relation.first_page?
     refute relation.last_page?
     assert_equal 2, relation.next_page
@@ -139,7 +140,17 @@ class Zaikio::Client::Helpers::Pagination::SpykeTest < ActiveSupport::TestCase
     })
 
     relation = User.all
+    assert relation.supports_pagination?
     refute relation.first_page?
     assert relation.last_page?
+  end
+
+  test "does not attempt to paginate if missing pagination headers" do
+    stub_request(:get, "https://api/users").to_return(body: '[{"id":1}]', headers: @headers)
+
+    relation = User.all
+    assert_equal [1], relation.map(&:id)
+
+    refute relation.supports_pagination?
   end
 end


### PR DESCRIPTION
* Add base class for all Spyke models to inherit from
* Rename Spyke module to avoid constant issues
* Gracefully handle when server responses don't have pagination headers (= we can use this module in all clients automatically)