### PR TITLE
Add `Zaikio:Error` and allow setting arbitrary attributes on exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Add `Zaikio:Error` and allow setting arbitrary attributes on the exceptions
+
 ## [0.1.1] - 2021-06-18
 
 - Require `zaikio/client/model` as part of gem loading to avoid need to load it elsewhere

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [Unreleased]
 
 - Add `Zaikio:Error` and allow setting arbitrary attributes on the exceptions
+- Add `Zaikio::RateLimitedError` when HTTP 429 occurs (note that this subclasses
+  `Zaikio::ConnectionError` so all existing error handling should continue to work).
 
 ## [0.1.1] - 2021-06-18
 

--- a/lib/zaikio-client-helpers.rb
+++ b/lib/zaikio-client-helpers.rb
@@ -2,6 +2,7 @@
 
 require_relative "zaikio/client/helpers/version"
 
+require_relative "zaikio/error"
 require_relative "zaikio/client/model"
 require_relative "zaikio/client/helpers/json_parser"
 require_relative "zaikio/client/helpers/pagination"

--- a/lib/zaikio/client/helpers/json_parser.rb
+++ b/lib/zaikio/client/helpers/json_parser.rb
@@ -6,13 +6,18 @@ module Zaikio::Client::Helpers
     def on_complete(env)
       connection_error(env) unless /^(2\d\d)|422|404$/.match?(env.status.to_s)
 
-      raise Spyke::ResourceNotFound if env.status.to_s == "404"
+      raise Spyke::ResourceNotFound.new("Not found", url: env.url) if env.status.to_s == "404"
 
       env.body = parse_body(env.body)
     end
 
     def connection_error(env)
-      raise Spyke::ConnectionError, "Status: #{env.status}, URL: #{env.url}, body: #{env.body}"
+      raise Spyke::ConnectionError.new(
+        "Status: #{env.status}, URL: #{env.url}, body: #{env.body}",
+        status: env.status,
+        url: env.url,
+        body: env.body
+      )
     end
 
     def parse_body(body)

--- a/lib/zaikio/error.rb
+++ b/lib/zaikio/error.rb
@@ -1,0 +1,29 @@
+module Zaikio
+  class Error < StandardError
+    def initialize(message = nil, **opts)
+      super(message)
+
+      opts.each do |key, value|
+        ivar = "@#{key}".to_sym
+        instance_variable_set(ivar, value)
+        define_singleton_method(key) { instance_variable_get(ivar) }
+      end
+    end
+  end
+
+  class ConnectionError < Zaikio::Error; end
+  class ResourceNotFound < Zaikio::Error; end
+end
+
+require "spyke"
+
+module Spyke
+  instance_eval do
+    # avoid warning: already initialized constant
+    remove_const("ConnectionError")
+    remove_const("ResourceNotFound")
+  end
+
+  ConnectionError = Class.new Zaikio::ConnectionError
+  ResourceNotFound = Class.new Zaikio::ResourceNotFound
+end

--- a/lib/zaikio/error.rb
+++ b/lib/zaikio/error.rb
@@ -11,8 +11,10 @@ module Zaikio
     end
   end
 
-  class ConnectionError < Zaikio::Error; end
   class ResourceNotFound < Zaikio::Error; end
+
+  class ConnectionError < Zaikio::Error; end
+  class RateLimitedError < ConnectionError; end
 end
 
 require "spyke"

--- a/test/zaikio/client/helpers/json_parser_test.rb
+++ b/test/zaikio/client/helpers/json_parser_test.rb
@@ -40,13 +40,18 @@ class Zaikio::Client::Helpers::JSONParserTest < ActiveSupport::TestCase
       @connection.get("/")
     end
     assert_equal "Status: 503, URL: https://parse/, body: Service unavailable", exception.message
+    assert_equal 503, exception.status
+    assert_equal URI("https://parse/"), exception.url
+    assert_equal "Service unavailable", exception.body
   end
 
   test "returns 404 if resource not found" do
     stub_request(:get, "https://parse/").to_return(status: 404)
 
-    assert_raises(Spyke::ResourceNotFound) do
+    exception = assert_raises(Spyke::ResourceNotFound) do
       @connection.get("/")
     end
+
+    assert_equal URI("https://parse/"), exception.url
   end
 end

--- a/test/zaikio/client/helpers/json_parser_test.rb
+++ b/test/zaikio/client/helpers/json_parser_test.rb
@@ -45,6 +45,25 @@ class Zaikio::Client::Helpers::JSONParserTest < ActiveSupport::TestCase
     assert_equal "Service unavailable", exception.body
   end
 
+  test "when server returns HTTP 422" do
+    stub_request(:patch, "https://parse/").to_return(status: 422, body: %({"errors":[]}))
+
+    response = assert_nothing_raised do
+      @connection.patch("/")
+    end
+
+    assert_equal({:data=>{:errors=>[]}, :metadata=>{}, :errors=>[]}, response.body)
+  end
+
+  test "when server returns HTTP 429" do
+    stub_request(:get, "https://parse/").to_return(status: 429, body: "Rate limited")
+
+    exception = assert_raises(Zaikio::RateLimitedError) do
+      @connection.get("/")
+    end
+    assert_equal URI("https://parse/"), exception.url
+  end
+
   test "returns 404 if resource not found" do
     stub_request(:get, "https://parse/").to_return(status: 404)
 


### PR DESCRIPTION
If we want to e.g. handle rate limiting, we can now do this:

```ruby
begin
  # client.get(..)
rescue Zaikio::ConnectionError => e
  retry if e.status = 429
  raise
end
```