### PR TITLE
Use Hash#dig for fetching pagination metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [0.2.2] - 2021-08-12
+
+- Attempt to fix `NoMethodError` when looking for pagination headers
+
 ## [0.2.1] - 2021-08-05
 
 - Fixed `with_fallback` from spyke by aliasing the correct error classes

--- a/lib/zaikio/client/helpers/pagination.rb
+++ b/lib/zaikio/client/helpers/pagination.rb
@@ -63,7 +63,7 @@ module Zaikio::Client::Helpers
     class Relation < Spyke::Relation
       HEADERS.each_key do |symbol|
         define_method(symbol) do
-          find_some.metadata[METADATA_KEY][symbol]
+          find_some.metadata.dig(METADATA_KEY, symbol)
         end
       end
 

--- a/lib/zaikio/client/helpers/version.rb
+++ b/lib/zaikio/client/helpers/version.rb
@@ -3,7 +3,7 @@
 module Zaikio
   module Client
     module Helpers
-      VERSION = "0.2.1"
+      VERSION = "0.2.2"
     end
   end
 end

--- a/zaikio-client-helpers.gemspec
+++ b/zaikio-client-helpers.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
 
+  spec.required_ruby_version = '>= 2.3'
+
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md",
                    "CHANGELOG.md"]
   spec.require_paths = ["lib"]


### PR DESCRIPTION
This helps protect against being nil. Unfortunately I could not accurately reproduce this issue:

```
  NoMethodError: undefined method `[]' for nil:NilClass
  zaikio-client-helpers (0.2.1) lib/zaikio/client/helpers/pagination.rb:66 block (2 levels) in <class:Relation>
  zaikio-client-helpers (0.2.1) lib/zaikio/client/helpers/pagination.rb:83 supports_pagination?
  zaikio-client-helpers (0.2.1) lib/zaikio/client/helpers/pagination.rb:98 each
  ...
```

It isn't easy to tell whether `metadata` is `nil`, or `metadata[PAGINATION_KEY]` is `nil`. The Spyke code indicates that
`metadata` is either `response[:metadata] || {}` so I presume that `metadata[PAGINATION_KEY]` is our culprit here, but I can't work out under what circumstances it would be so.

Anyway - if we didn't parse the pagination headers correctly, the response won't support pages, so we can safely return nil.