### PR TITLE
Support pagination when response lacks a total count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Handle "uncountable" responses (i.e. those without a Total-Count or Total-Pages header)
+
 ## [0.2.2] - 2021-08-12
 
 - Attempt to fix `NoMethodError` when looking for pagination headers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+## [0.2.3] - 2021-11-12
+
 - Handle "uncountable" responses (i.e. those without a Total-Count or Total-Pages header)
 
 ## [0.2.2] - 2021-08-12

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    zaikio-client-helpers (0.2.1)
+    zaikio-client-helpers (0.2.2)
       faraday
       multi_json
       spyke
@@ -9,9 +9,9 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.1.4)
-      activesupport (= 6.1.4)
-    activesupport (6.1.4)
+    activemodel (6.1.4.1)
+      activesupport (= 6.1.4.1)
+    activesupport (6.1.4.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -24,7 +24,7 @@ GEM
     concurrent-ruby (1.1.9)
     crack (0.4.5)
       rexml
-    faraday (1.6.0)
+    faraday (1.8.0)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -43,10 +43,10 @@ GEM
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
-    faraday_middleware (1.1.0)
+    faraday_middleware (1.2.0)
       faraday (~> 1.0)
     hashdiff (1.0.1)
-    i18n (1.8.10)
+    i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     method_source (1.0.0)
     minitest (5.14.4)
@@ -75,11 +75,12 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    zeitwerk (2.4.2)
+    zeitwerk (2.5.1)
 
 PLATFORMS
   x86_64-darwin-19
   x86_64-darwin-20
+  x86_64-darwin-21
 
 DEPENDENCIES
   minitest (~> 5.0)
@@ -90,4 +91,4 @@ DEPENDENCIES
   zaikio-client-helpers!
 
 BUNDLED WITH
-   2.2.16
+   2.2.30

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    zaikio-client-helpers (0.2.2)
+    zaikio-client-helpers (0.2.3)
       faraday
       multi_json
       spyke

--- a/lib/zaikio/client/helpers/pagination.rb
+++ b/lib/zaikio/client/helpers/pagination.rb
@@ -76,7 +76,11 @@ module Zaikio::Client::Helpers
       end
 
       def last_page?
-        current_page >= total_pages
+        if total_pages.nil?
+          find_some.empty?
+        else
+          current_page >= total_pages
+        end
       end
 
       def supports_pagination?

--- a/lib/zaikio/client/helpers/version.rb
+++ b/lib/zaikio/client/helpers/version.rb
@@ -3,7 +3,7 @@
 module Zaikio
   module Client
     module Helpers
-      VERSION = "0.2.2"
+      VERSION = "0.2.3"
     end
   end
 end

--- a/test/zaikio/client/helpers/pagination_test.rb
+++ b/test/zaikio/client/helpers/pagination_test.rb
@@ -165,6 +165,20 @@ class Zaikio::Client::Helpers::PaginationTest < ActiveSupport::TestCase
     refute relation.supports_pagination?
   end
 
+  test "will attempt to paginate when working with uncountable responses" do
+    stub_request(:get, "https://api/users").to_return(body: '[{"id":1}]', headers: {
+      "Current-Page" => 1
+    })
+    stub_request(:get, "https://api/users?page=2").to_return(body: '[]', headers: {
+      "Current-Page" => 2
+    })
+
+    relation = User.all
+    assert_equal [1], relation.map(&:id)
+
+    assert relation.supports_pagination?
+  end
+
   test "does not attempt to paginate if unexpected content type" do
     stub_request(:get, "https://api/users")
       .to_return(body: '<html>', headers: { "Content-Type" => "text/plain"})


### PR DESCRIPTION
When using Pagy, sometimes responses can be uncountable, in which case we should always assume there is another page (and that next page may be empty, so we should abort).