### PR TITLE
Add support for Faraday 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [0.2.4] - 2022-03-29
+
+- Add support for Faraday 2.x
+
 ## [0.2.3] - 2021-11-12
 
 - Handle "uncountable" responses (i.e. those without a Total-Count or Total-Pages header)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,55 +1,58 @@
 PATH
   remote: .
   specs:
-    zaikio-client-helpers (0.2.3)
-      faraday
+    zaikio-client-helpers (0.2.4)
+      faraday (>= 1, < 3)
       multi_json
-      spyke
+      spyke (~> 6)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.1.4.1)
-      activesupport (= 6.1.4.1)
-    activesupport (6.1.4.1)
+    activemodel (7.0.2.3)
+      activesupport (= 7.0.2.3)
+    activesupport (7.0.2.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
     byebug (11.1.3)
     coderay (1.1.3)
-    concurrent-ruby (1.1.9)
+    concurrent-ruby (1.1.10)
     crack (0.4.5)
       rexml
-    faraday (1.8.0)
+    faraday (1.10.0)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
-      faraday-httpclient (~> 1.0.1)
+      faraday-httpclient (~> 1.0)
+      faraday-multipart (~> 1.0)
       faraday-net_http (~> 1.0)
-      faraday-net_http_persistent (~> 1.1)
+      faraday-net_http_persistent (~> 1.0)
       faraday-patron (~> 1.0)
       faraday-rack (~> 1.0)
-      multipart-post (>= 1.2, < 3)
+      faraday-retry (~> 1.0)
       ruby2_keywords (>= 0.0.4)
     faraday-em_http (1.0.0)
     faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
     faraday-httpclient (1.0.1)
+    faraday-multipart (1.0.3)
+      multipart-post (>= 1.2, < 3)
     faraday-net_http (1.0.1)
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
+    faraday-retry (1.0.3)
     faraday_middleware (1.2.0)
       faraday (~> 1.0)
     hashdiff (1.0.1)
-    i18n (1.8.11)
+    i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     method_source (1.0.0)
-    minitest (5.14.4)
+    minitest (5.15.0)
     multi_json (1.15.0)
     multipart-post (2.1.1)
     pry (0.13.1)
@@ -62,7 +65,7 @@ GEM
     rake (13.0.3)
     rexml (3.2.5)
     ruby2_keywords (0.0.5)
-    spyke (6.0.0)
+    spyke (6.1.3)
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)
       addressable (>= 2.5.2)
@@ -75,7 +78,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    zeitwerk (2.5.1)
 
 PLATFORMS
   x86_64-darwin-19
@@ -91,4 +93,4 @@ DEPENDENCIES
   zaikio-client-helpers!
 
 BUNDLED WITH
-   2.2.30
+   2.3.6

--- a/lib/zaikio/client/helpers/json_parser.rb
+++ b/lib/zaikio/client/helpers/json_parser.rb
@@ -2,7 +2,13 @@ require "faraday"
 require "multi_json"
 
 module Zaikio::Client::Helpers
-  class JSONParser < Faraday::Response::Middleware
+  superclass = if Gem.loaded_specs["faraday"].version >= Gem::Version.new("2.0")
+    Faraday::Middleware
+  else
+    Faraday::Response::Middleware
+  end
+
+  JSONParser = Class.new(superclass) do
     def on_complete(env)
       case env.status
       when 404 then raise Spyke::ResourceNotFound.new(nil, url: env.url)

--- a/lib/zaikio/client/helpers/pagination.rb
+++ b/lib/zaikio/client/helpers/pagination.rb
@@ -11,6 +11,12 @@ module Zaikio::Client::Helpers
 
     METADATA_KEY = :pagination
 
+    superclass = if Gem.loaded_specs["faraday"].version >= Gem::Version.new("2.0")
+      Faraday::Middleware
+    else
+      Faraday::Response::Middleware
+    end
+
     # Faraday Middleware for extracting any pagination headers into the a top-level
     # :metadata hash, or the env hash for non-JSON responses.
     #
@@ -22,7 +28,7 @@ module Zaikio::Client::Helpers
     #   response = conn.get("/")
     #   response.env[METADATA_KEY]
     #   #=> {total_count: 4, total_pages: 1, current_page: 1}
-    class FaradayMiddleware < Faraday::Response::Middleware
+    FaradayMiddleware = Class.new(superclass) do
       def on_complete(env)
         @env = env
 

--- a/lib/zaikio/client/helpers/version.rb
+++ b/lib/zaikio/client/helpers/version.rb
@@ -3,7 +3,7 @@
 module Zaikio
   module Client
     module Helpers
-      VERSION = "0.2.3"
+      VERSION = "0.2.4"
     end
   end
 end

--- a/zaikio-client-helpers.gemspec
+++ b/zaikio-client-helpers.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |spec|
                    "CHANGELOG.md"]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday"
+  spec.add_dependency "faraday", ">= 1", "< 3"
   spec.add_dependency "multi_json"
-  spec.add_dependency "spyke"
+  spec.add_dependency "spyke", "~> 6"
 
   spec.add_development_dependency "vcr"
   spec.add_development_dependency "webmock"


### PR DESCRIPTION
They changed the middleware namespace, so we need to support both for the time being 🤮 