### PR TITLE
Add a default timeout for faraday

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Add a default timeout for Faraday connection of 5 seconds.
+
 ## [0.3.0] - 2022-08-15
 
 - Add `Zaikio::Client::Helpers::AuthorizationMiddleware` and `Zaikio::Client.with_token` to pass down bearer token to multiple clients (e.g. hub + procurement) at the same time

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [Unreleased]
 
-- Add a default timeout for Faraday connection of 5 seconds.
+- Add a default read timeout for Faraday connection of 5 seconds, and open timeout of 1 second.
 
 ## [0.3.0] - 2022-08-15
 

--- a/lib/zaikio/client.rb
+++ b/lib/zaikio/client.rb
@@ -18,6 +18,7 @@ module Zaikio
       def create_connection(configuration)
         Faraday.new(url: configuration.host,
                                       ssl: { verify: configuration.environment != :test }) do |c|
+          c.options.timeout = 5
           c.request     :json
           c.response    :logger, configuration&.logger, headers: false
           c.use         Zaikio::Client::Helpers::Pagination::FaradayMiddleware

--- a/lib/zaikio/client.rb
+++ b/lib/zaikio/client.rb
@@ -18,7 +18,8 @@ module Zaikio
       def create_connection(configuration)
         Faraday.new(url: configuration.host,
                                       ssl: { verify: configuration.environment != :test }) do |c|
-          c.options.timeout = 5
+          c.options.read_timeout = 5
+          c.options.open_timeout = 1
           c.request     :json
           c.response    :logger, configuration&.logger, headers: false
           c.use         Zaikio::Client::Helpers::Pagination::FaradayMiddleware


### PR DESCRIPTION
We should rather see timeout errors from faraday (so we can handle them), see https://github.com/zaikio/keyline/issues/2664