### PR TITLE
Add middleware that sets the I18n.locale as query param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-- Add new faraday middleware that automatically passes current `I18n.locale` to `lang` param
+- Add new faraday middleware that automatically passes current `I18n.locale` to `Accept-Language` header
 
 ## [0.4.0] - 2023-02-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Add new faraday middleware that automatically passes current `I18n.locale` to `lang` param
+
 ## [0.4.0] - 2023-02-09
 
 - Add a default read timeout for Faraday connection of 5 seconds, and open timeout of 1 second.

--- a/lib/zaikio/client.rb
+++ b/lib/zaikio/client.rb
@@ -3,6 +3,7 @@ require "zaikio/client/helpers/json_parser"
 require "zaikio/client/helpers/pagination"
 require "zaikio/client/helpers/configuration"
 require "zaikio/client/helpers/authorization_middleware"
+require "zaikio/client/helpers/locale_middleware"
 
 module Zaikio
   module Client
@@ -25,6 +26,7 @@ module Zaikio
           c.use         Zaikio::Client::Helpers::Pagination::FaradayMiddleware
           c.use         Zaikio::Client::Helpers::JSONParser
           c.use         Zaikio::Client::Helpers::AuthorizationMiddleware
+          c.use         Zaikio::Client::Helpers::LocaleMiddleware, disable_i18n: configuration.disable_i18n
           c.adapter     Faraday.default_adapter
         end
       end

--- a/lib/zaikio/client/helpers/configuration.rb
+++ b/lib/zaikio/client/helpers/configuration.rb
@@ -4,7 +4,7 @@ module Zaikio
   module Client
     module Helpers
       class Configuration
-        attr_accessor :host
+        attr_accessor :host, :disable_i18n
         attr_reader :environment
         attr_writer :logger
 

--- a/lib/zaikio/client/helpers/locale_middleware.rb
+++ b/lib/zaikio/client/helpers/locale_middleware.rb
@@ -1,0 +1,32 @@
+require "faraday"
+
+module Zaikio
+  module Client
+    module Helpers
+      class LocaleMiddleware < Faraday::Middleware
+        def initialize(app, disable_i18n: false)
+          @disable_i18n = disable_i18n
+          super(app)
+        end
+
+        def call(request_env)
+          if !@disable_i18n && Object.const_defined?("I18n")
+            request_env.url.query = add_query_param(request_env.url.query, "lang", ::I18n.try(:locale))
+          end
+
+          @app.call(request_env)
+        end
+
+        private
+
+        def add_query_param(query, key, value)
+          query = [query.to_s]
+          query << "&" unless query.empty?
+          query << "#{Faraday::Utils.escape key}=#{Faraday::Utils.escape value}"
+
+          query.join
+        end
+      end
+    end
+  end
+end

--- a/lib/zaikio/client/helpers/locale_middleware.rb
+++ b/lib/zaikio/client/helpers/locale_middleware.rb
@@ -11,20 +11,10 @@ module Zaikio
 
         def call(request_env)
           if !@disable_i18n && Object.const_defined?("I18n")
-            request_env.url.query = add_query_param(request_env.url.query, "lang", ::I18n.try(:locale))
+            request_env[:request_headers]["Accept-Language"] = ::I18n.try(:locale)&.to_s
           end
 
           @app.call(request_env)
-        end
-
-        private
-
-        def add_query_param(query, key, value)
-          query = [query.to_s]
-          query << "&" unless query.empty?
-          query << "#{Faraday::Utils.escape key}=#{Faraday::Utils.escape value}"
-
-          query.join
         end
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,3 +19,5 @@ VCR.configure do |config|
 end
 
 require "zaikio-client-helpers"
+
+I18n.available_locales = [:de, :en]

--- a/test/zaikio/client/helpers/authorization_middleware_test.rb
+++ b/test/zaikio/client/helpers/authorization_middleware_test.rb
@@ -15,8 +15,8 @@ class Zaikio::Client::Helpers::AuthorizationMiddlewareTest < ActiveSupport::Test
   end
 
   test "it sets the Authorization request header" do
-    stub_request(:get, "https://procurement.sandbox.zaikio.com/api/v2/resources?lang=en")
-    stub_request(:get, "https://procurement.sandbox.zaikio.com/api/v2/resources2?lang=en")
+    stub_request(:get, "https://procurement.sandbox.zaikio.com/api/v2/resources")
+    stub_request(:get, "https://procurement.sandbox.zaikio.com/api/v2/resources2")
 
     Zaikio::Client.with_token("oldtoken") do
       Zaikio::Client.with_token("mytoken") do
@@ -27,12 +27,12 @@ class Zaikio::Client::Helpers::AuthorizationMiddlewareTest < ActiveSupport::Test
     end
 
     assert_requested(
-      :get, "https://procurement.sandbox.zaikio.com/api/v2/resources?lang=en",
+      :get, "https://procurement.sandbox.zaikio.com/api/v2/resources",
       headers: { "Authorization" => "Bearer oldtoken" }
     )
 
     assert_requested(
-      :get, "https://procurement.sandbox.zaikio.com/api/v2/resources2?lang=en",
+      :get, "https://procurement.sandbox.zaikio.com/api/v2/resources2",
       headers: { "Authorization" => "Bearer mytoken" }
     )
   end

--- a/test/zaikio/client/helpers/authorization_middleware_test.rb
+++ b/test/zaikio/client/helpers/authorization_middleware_test.rb
@@ -15,8 +15,8 @@ class Zaikio::Client::Helpers::AuthorizationMiddlewareTest < ActiveSupport::Test
   end
 
   test "it sets the Authorization request header" do
-    stub_request(:get, "https://procurement.sandbox.zaikio.com/api/v2/resources")
-    stub_request(:get, "https://procurement.sandbox.zaikio.com/api/v2/resources2")
+    stub_request(:get, "https://procurement.sandbox.zaikio.com/api/v2/resources?lang=en")
+    stub_request(:get, "https://procurement.sandbox.zaikio.com/api/v2/resources2?lang=en")
 
     Zaikio::Client.with_token("oldtoken") do
       Zaikio::Client.with_token("mytoken") do
@@ -27,12 +27,12 @@ class Zaikio::Client::Helpers::AuthorizationMiddlewareTest < ActiveSupport::Test
     end
 
     assert_requested(
-      :get, "https://procurement.sandbox.zaikio.com/api/v2/resources",
+      :get, "https://procurement.sandbox.zaikio.com/api/v2/resources?lang=en",
       headers: { "Authorization" => "Bearer oldtoken" }
     )
 
     assert_requested(
-      :get, "https://procurement.sandbox.zaikio.com/api/v2/resources2",
+      :get, "https://procurement.sandbox.zaikio.com/api/v2/resources2?lang=en",
       headers: { "Authorization" => "Bearer mytoken" }
     )
   end

--- a/test/zaikio/client/helpers/locale_middleware_test.rb
+++ b/test/zaikio/client/helpers/locale_middleware_test.rb
@@ -19,32 +19,32 @@ class Zaikio::Client::Helpers::LocaleMiddlewareTest < ActiveSupport::TestCase
   test "it sets the lang query param" do
     @connection = create_connection
     
-    stub_request(:get, "https://procurement.sandbox.zaikio.com/api/v2/resources?anotherparam=1&lang=de")
+    stub_request(:get, "https://procurement.sandbox.zaikio.com/api/v2/resources")
 
     I18n.with_locale(:de) do
       Zaikio::Client.with_token("token") do
-        @connection.get("resources?anotherparam=1")
+        @connection.get("resources")
       end
     end
 
     assert_requested(
-      :get, "https://procurement.sandbox.zaikio.com/api/v2/resources?anotherparam=1&lang=de",
-      headers: { "Authorization" => "Bearer token" }
+      :get, "https://procurement.sandbox.zaikio.com/api/v2/resources",
+      headers: { "Authorization" => "Bearer token", "Accept-Language" => "de" }
     )
   end
 
   test "it does not set the lang query param if disabled" do
     @connection = create_connection(disable_i18n: true)
-    stub_request(:get, "https://procurement.sandbox.zaikio.com/api/v2/resources?anotherparam=1")
+    stub_request(:get, "https://procurement.sandbox.zaikio.com/api/v2/resources")
 
     I18n.with_locale(:de) do
       Zaikio::Client.with_token("token") do
-        @connection.get("resources?anotherparam=1")
+        @connection.get("resources")
       end
     end
 
     assert_requested(
-      :get, "https://procurement.sandbox.zaikio.com/api/v2/resources?anotherparam=1",
+      :get, "https://procurement.sandbox.zaikio.com/api/v2/resources",
       headers: { "Authorization" => "Bearer token" }
     )
   end

--- a/test/zaikio/client/helpers/locale_middleware_test.rb
+++ b/test/zaikio/client/helpers/locale_middleware_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Zaikio::Client::Helpers::LocaleMiddlewareTest < ActiveSupport::TestCase
+  def create_connection(disable_i18n: false)
+    @config_class = Class.new(Zaikio::Client::Helpers::Configuration) do
+      def self.hosts
+        {
+          sandbox: "https://procurement.sandbox.zaikio.com/api/v2/"
+        }.freeze
+      end
+    end
+    @config = @config_class.new
+    @config.disable_i18n = disable_i18n
+    Zaikio::Client.create_connection(@config)
+  end
+
+  test "it sets the lang query param" do
+    @connection = create_connection
+    
+    stub_request(:get, "https://procurement.sandbox.zaikio.com/api/v2/resources?anotherparam=1&lang=de")
+
+    I18n.with_locale(:de) do
+      Zaikio::Client.with_token("token") do
+        @connection.get("resources?anotherparam=1")
+      end
+    end
+
+    assert_requested(
+      :get, "https://procurement.sandbox.zaikio.com/api/v2/resources?anotherparam=1&lang=de",
+      headers: { "Authorization" => "Bearer token" }
+    )
+  end
+
+  test "it does not set the lang query param if disabled" do
+    @connection = create_connection(disable_i18n: true)
+    stub_request(:get, "https://procurement.sandbox.zaikio.com/api/v2/resources?anotherparam=1")
+
+    I18n.with_locale(:de) do
+      Zaikio::Client.with_token("token") do
+        @connection.get("resources?anotherparam=1")
+      end
+    end
+
+    assert_requested(
+      :get, "https://procurement.sandbox.zaikio.com/api/v2/resources?anotherparam=1",
+      headers: { "Authorization" => "Bearer token" }
+    )
+  end
+end


### PR DESCRIPTION
Some APIs require localized responses. Instead of doing this on every request it would be helpful to automatically set Rails' `I18n.locale`.

Across all Zaikio APIs we use the `lang` query param.

Needed for Keyline Warehouse integration.